### PR TITLE
Add Documentation Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ and reports.
 The purpose of this is to work directly with Jira's API, which gives a lot more rich data, allowing us to get the
 reports we want with minimal manual exporting, copying and pasting.
 
+## Documentation
+You can check out the reference documentation [here](https://docs.contour.so/hotjar/jira-analysis/getting-started).
+
+
 ## License
 
 [MIT](./LICENSE)


### PR DESCRIPTION
[**Linked Issue**](https://github.com/hotjar/jira-analysis/issues/10)

I opened an issue regarding of there not being documentation for this repository for this pull request. 

Although I'm not sure how helpful it is, this PR should have a link to the generated documentation. Nonetheless, it comes with a full WYSIWIG Markdown editor that you can use to edit/create the documentation.



